### PR TITLE
Bug! Provision failing

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -2,7 +2,6 @@
 
 DOCKER_INSTALLER_URL="https://get.docker.com/"
 DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | tail -n 1)
-# RVM_INSTALLER_URL="https://get.rvm.io"
 RVM_INSTALLER_URL="https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer"
 CODEDEPLOY_INSTALLER_URL="https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install"
 
@@ -34,13 +33,16 @@ usermod -aG docker ubuntu
 service docker start
 
 # docker-compose
-curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o "/usr/local/bin/docker-compose"
+curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" \
+     -o "/usr/local/bin/docker-compose"
 sudo chmod +x /usr/local/bin/docker-compose
-curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose" -o "/etc/bash_completion.d/docker-compose"
+curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose" \
+     -o "/etc/bash_completion.d/docker-compose"
 
 # ruby
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby={2.3.0,2.4.1,2.4.2,2.4.3} --gems=bundler,dotenv,pry
+gpg --keyserver hkp://keys.gnupg.net \
+    --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby=2.5 --gems=bundler,dotenv,pry
 usermod -aG rvm root
 usermod -aG rvm ubuntu
 

--- a/bin/provision
+++ b/bin/provision
@@ -39,7 +39,7 @@ sudo chmod +x /usr/local/bin/docker-compose
 curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose version --short)/contrib/completion/bash/docker-compose" -o "/etc/bash_completion.d/docker-compose"
 
 # ruby
-curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby={2.3.0,2.4.1,2.4.2,2.4.3} --gems=bundler,dotenv,pry
 usermod -aG rvm root
 usermod -aG rvm ubuntu

--- a/bin/provision
+++ b/bin/provision
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DOCKER_INSTALLER_URL="https://get.docker.com/"
-DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | grep refs/tags | grep -oP "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | tail -n 1)
+DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | grep refs/tags | grep -oP "[0-9]+\\.[0-9][0-9]+\\.[0-9]+$" | tail -n 1)
 RVM_INSTALLER_URL="https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer"
 CODEDEPLOY_INSTALLER_URL="https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install"
 MONITORING_INSTALLER_URL="https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip"


### PR DESCRIPTION
## Wut
* Deployed a new ASG instance (mm-aes in this case)...codedeploy deployment hung and failed.

## Why
* Snippit from `cloud-init-output.log`:
```sh
gpg: key D39DC0E3: public key "Michal Papis (RVM signing) <mpapis@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
gpg:               imported: 1  (RSA: 1)
gpg: no ultimately trusted keys found
Downloading https://github.com/rvm/rvm/archive/1.29.6.tar.gz
Downloading https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc
gpg: Signature made Thu Dec 13 15:09:53 2018 UTC using RSA key ID 39499BDB
gpg: Can't check signature: public key not found
Warning, RVM 1.26.0 introduces signed releases and automated check of signatures when GPG software found. Assuming you trust Michal Papis import the mpapis public key (downloading the signatures).

GPG signature verification failed for '/usr/local/rvm/archives/rvm-1.29.6.tgz' - 'https://github.com/rvm/rvm/releases/download/1.29.6/1.29.6.tar.gz.asc'! Try to install GPG v2 and then fetch the public key:

    gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB

or if it fails:

    command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
    command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -

the key can be compared with:

    https://rvm.io/mpapis.asc or https://keybase.io/mpapis
    https://rvm.io/pkuczynski.asc

NOTE: GPG version 2.1.17 have a bug which cause failures during fetching keys from remote server. Please downgrade or upgrade to newer version (if available) or use the second method described above.

usermod: group 'rvm' does not exist
```

* TL;DR - RVM install failed and prevented starting codedeploy agent. Looks like the [instructions](https://rvm.io/rvm/install) have an updated 'Install GPG Keys' command.
* Updated GPG key install