### PR TITLE
Add AWS CLI installation to provision script

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -5,6 +5,7 @@ DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | gre
 RVM_INSTALLER_URL="https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer"
 CODEDEPLOY_INSTALLER_URL="https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install"
 MONITORING_INSTALLER_URL="https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip"
+AWSCLI_INSTALLER_URL="https://s3.amazonaws.com/aws-cli/awscli-bundle.zip"
 
 # hostname config (for sudo to work properly)
 echo "$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)" "$(hostname)" | sudo tee -a /etc/hosts
@@ -63,6 +64,11 @@ wget "$CODEDEPLOY_INSTALLER_URL"
 chmod +x ./install
 bash -l -c "ruby ./install auto"
 service codedeploy-agent start
+
+# awscli
+curl "$AWSCLI_INSTALLER_URL" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # csysdig: container htop
 curl -s https://s3.amazonaws.com/download.draios.com/DRAIOS-GPG-KEY.public | apt-key add -


### PR DESCRIPTION
### Why is this pull request necessary?
* To enable easy authentication to our private ECR, we need the `awscli`

### How does it fix the issue?
* Adds install steps as found in the aws [docs](https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html#install-bundle-other)

### What side effects might this have?
* Shouldn't