### PR TITLE
Parameter Tags

### DIFF
--- a/lib/shipshape/cmd/env.rb
+++ b/lib/shipshape/cmd/env.rb
@@ -17,7 +17,7 @@ module Shipshape
 
     def push(*args)
       @prefix = Prefix.new(*args)
-      put_parameters(*exist_locally)
+      put_parameters(prefix, *exist_locally)
     end
 
     desc 'pull APP_NAME APP_ENV',


### PR DESCRIPTION
### Why is this pull request necessary?
* Wanted to add tags to parameter store values for easy filtering in the console

### How does it fix the issue?
* Add tags based on the app_env and app_name during `env push`.

### What side effects might this have?
* Can now click the search bar and select `Tag key` and use the env and/or project name to scope what is shown