### PR TITLE
SIR-1180-need-to-delete-env-params

### DIFF
--- a/lib/shipshape/actions/aws/parameter_store.rb
+++ b/lib/shipshape/actions/aws/parameter_store.rb
@@ -26,6 +26,12 @@ module Shipshape
           }
         end
 
+        def delete_parameters(*params)
+          params.each { |param|
+            ssm_client.delete_parameter(name: param[:name])
+          }
+        end
+
         private
 
         def ssm_client

--- a/lib/shipshape/actions/aws/simple_storage_service.rb
+++ b/lib/shipshape/actions/aws/simple_storage_service.rb
@@ -29,7 +29,7 @@ module Shipshape
             [
               :encrypt,
               type: :boolean,
-              default: false,
+              default: true,
               aliases: %w[-e --e],
               desc: 'Whether or not to encrypt/unencrypt the specified S3 object'
             ]

--- a/lib/shipshape/cmd/env.rb
+++ b/lib/shipshape/cmd/env.rb
@@ -29,6 +29,15 @@ module Shipshape
       env_file.write(modified_locals)
     end
 
+    desc 'purge APP_NAME APP_ENV',
+         'Deletes all parameters in parameter store for given app and env.' \
+         'Authenticates using AWS credentials in env or ~/.aws/credentials.'
+
+    def purge(*args)
+      @prefix = Prefix.new(*args)
+      delete_parameters(*remote_params)
+    end
+
     private
 
     class Prefix < DelegateClass(String)


### PR DESCRIPTION
### Why is this pull request necessary?
Sometimes env vars get out of whack in the parameter store and need to get a clean slate for an app's env. For example, if some environment variables get pushed unencrypted, then others get pushed encrypted, when those variables get pulled, the encryption may not work.

### How does it fix the issue?
- Adds command to delete all parameters for a given env/app prefix.
- Makes encryption the default. (Can always turn this off with `--no-encrypt` option.)

### What side effects might this have?
