### PR TITLE
DEV-33: env push variable parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ git clone <repo>
 cd <repo>
 bundle
 gem build shipshape.gemspec
-gem install shipshape-0.2.0
+gem install shipshape-0.2.3
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version,
 push git commits and tags.
 
+To invoke cli without installation, run `bundle exec ./exe/shipshape <command>`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/sesac/shipshape. This project is

--- a/lib/shipshape/cmd/env.rb
+++ b/lib/shipshape/cmd/env.rb
@@ -12,8 +12,9 @@ module Shipshape
     attr_reader :prefix
 
     desc 'push APP_NAME APP_ENV',
-         'Push values in .env file to AWS Parameter Store. ' \
-         'Authenticates using AWS credentials in env or ~/.aws/credentials.'
+         "Push values in .env file to AWS Parameter Store. \n" \
+         "Authenticates using AWS credentials in env or ~/.aws/credentials. \n" \
+         "NOTE: to avoid dotenv parsing special characters such as $, enclose variable in single quotes." \
 
     def push(*args)
       @prefix = Prefix.new(*args)

--- a/lib/shipshape/version.rb
+++ b/lib/shipshape/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shipshape
-  VERSION = '0.2.0'
+  VERSION = '0.2.3'
 end

--- a/shipshape.gemspec
+++ b/shipshape.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'simplecov', '~> 0.14'
 end


### PR DESCRIPTION
### Why is this pull request necessary?
* When pushing variables to parameter store that have been read from an `.env` or equivalent, sometime the values can get parsed in unexpected ways.
* Example `TEST_VAR=asdf$fdas` will get pushed as `TEST_VAR=asdf`.

### How does it fix the issue?
* Update help message to note a workaround using single quotes to enclose the var, ex: `TEST_VAR='asdf$fdas'`
* Update rubocop version to fix known vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2017-8418)
* Bump gem version.

### What side effects might this have?
* If env file is also being used to pass variables to a projects' docker containers using compose, enclosing in quotes will be passed to running containers unchanged, which is likely undesired. (see https://docs.docker.com/compose/env-file/)