### PR TITLE
Docker compose version

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 DOCKER_INSTALLER_URL="https://get.docker.com/"
-DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | grep refs/tags | grep -oP "[0-9]+\\.[0-9][0-9]+\\.[0-9]+$" | tail -n 1)
+# version hard-coded to prevent installing unknown (potentially broken) versions of compose.
+# https://github.com/docker/compose/issues/6268#issuecomment-576628705
+DOCKER_COMPOSE_VERSION=1.25.4
 RVM_INSTALLER_URL="https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer"
 CODEDEPLOY_INSTALLER_URL="https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install"
 MONITORING_INSTALLER_URL="https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip"

--- a/bin/provision_by_env
+++ b/bin/provision_by_env
@@ -3,7 +3,9 @@
 set -u
 
 ENV="$1"
-DOCKER_COMPOSE_VERSION=$(git ls-remote "https://github.com/docker/compose" | grep refs/tags | grep -oP "v*[0-9]+\\.[0-9][0-9]+\\.[0-9]+$" | tail -n 1)
+# version hard-coded to prevent installing unknown (potentially broken) versions of compose.
+# https://github.com/docker/compose/issues/6268#issuecomment-576628705
+DOCKER_COMPOSE_VERSION=1.25.4
 RVM_INSTALLER_URL="https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer"
 CODEDEPLOY_INSTALLER_URL="https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install"
 MONITORING_INSTALLER_URL="https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip"


### PR DESCRIPTION
### Why is this pull request necessary?
* Ran into a situation where the format of docker-compose tags [were inconsistent](https://github.com/docker/compose/issues/6268#issuecomment-576628705), and our dynamic evaluation of the most recent tag was pointing to an outdated and broken version - causing replaced/new EC2 instances to fail.

### How does it fix the issue?
* Pin the compose version to the most recent known working version.

### What side effects might this have?