### PR TITLE
BUG - ASGs failing in provision script

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -48,7 +48,7 @@ curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose versi
      -o "/etc/bash_completion.d/docker-compose"
 
 # ruby
-gpg --keyserver hkp://pgp.mit.edu \
+gpg2 --keyserver hkp://pgp.mit.edu \
     --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby=2.5 --gems=bundler,dotenv,pry
 usermod -aG rvm root

--- a/bin/provision
+++ b/bin/provision
@@ -32,7 +32,8 @@ apt-get install -y \
         python-pip \
         unzip \
         libwww-perl \
-        libdatetime-perl
+        libdatetime-perl \
+        gnupg2
 
 # docker
 wget -qO- "$DOCKER_INSTALLER_URL" | sh
@@ -47,7 +48,7 @@ curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose versi
      -o "/etc/bash_completion.d/docker-compose"
 
 # ruby
-gpg --keyserver hkp://keys.gnupg.net \
+gpg --keyserver hkp://pgp.mit.edu \
     --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby=2.5 --gems=bundler,dotenv,pry
 usermod -aG rvm root

--- a/bin/provision
+++ b/bin/provision
@@ -65,7 +65,7 @@ cat <(grep -F -i -v "$command" <(crontab -l)) <(echo "$job") | crontab -
 cd /home/ubuntu || true
 wget "$CODEDEPLOY_INSTALLER_URL"
 chmod +x ./install
-bash -l -c "ruby ./install auto -v releases/codedeploy-agent-1.3.1.rpm"
+bash -l -c "ruby ./install auto"
 service codedeploy-agent start
 
 # awscli

--- a/bin/provision
+++ b/bin/provision
@@ -48,7 +48,7 @@ curl -L "https://raw.githubusercontent.com/docker/compose/$(docker-compose versi
      -o "/etc/bash_completion.d/docker-compose"
 
 # ruby
-gpg2 --keyserver hkp://pgp.mit.edu \
+sudo gpg2 --keyserver hkp://pgp.mit.edu \
     --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL "$RVM_INSTALLER_URL" | bash -s stable --ruby=2.5 --gems=bundler,dotenv,pry
 usermod -aG rvm root

--- a/bin/provision
+++ b/bin/provision
@@ -64,7 +64,7 @@ cat <(grep -F -i -v "$command" <(crontab -l)) <(echo "$job") | crontab -
 cd /home/ubuntu || true
 wget "$CODEDEPLOY_INSTALLER_URL"
 chmod +x ./install
-bash -l -c "ruby ./install auto"
+bash -l -c "ruby ./install auto -v releases/codedeploy-agent-1.3.1.rpm"
 service codedeploy-agent start
 
 # awscli


### PR DESCRIPTION
### Why is this pull request necessary?
AutoScaling Groups have been failing due to, seemingly, not having the CodeDeploy agent installed on the instance. Some investigating found that the issue was actually a step earlier, installing Ruby via RVM. 

### How does it fix the issue?
* Update to gpg2
* change to keyserver to one of the suggestions at rvm.io/rvm/security that actually works
* sudo the gpg2 command to allow the keys to be properly passed to RVM

### What side effects might this have?
None