### PR TITLE
Hotfix - systemctl for service

### DIFF
--- a/bin/provision
+++ b/bin/provision
@@ -42,7 +42,7 @@ wget "$CODEDEPLOY_INSTALLER_URL"
 chmod +x install
 bash -l -c "sudo ./install auto"
 #sudo ./install auto
-service codedeploy-agent start
+systemctl start codedeploy-agent
 
 # docker
 wget -qO- "$DOCKER_INSTALLER_URL" | sh

--- a/bin/provision_by_env
+++ b/bin/provision_by_env
@@ -97,7 +97,7 @@ wget "$CODEDEPLOY_INSTALLER_URL"
 chmod +x install
 bash -l -c "sudo ./install auto"
 #sudo ./install auto
-service codedeploy-agent start
+systemctl start codedeploy-agent
 
 # awscli
 curl "$AWSCLI_INSTALLER_URL" -o "awscli-bundle.zip"


### PR DESCRIPTION
### Why is this pull request necessary?
AWS Says to use systemctl 

### How does it fix the issue?
swap for systemctl start codedeploy-agent per  https://docs.aws.amazon.com/codedeploy/latest/userguide/codedeploy-agent-operations-install-linux.html


### What side effects might this have?
